### PR TITLE
Create 康托展开.C

### DIFF
--- a/康托展开.C
+++ b/康托展开.C
@@ -1,0 +1,28 @@
+//康托展开
+#include<stdio.h>
+int cantor(int a[], int n);
+int main()
+{
+	int s[] = {3,4,1,5,2};
+	int t;
+	t=cantor(s, sizeof(s) / 4);
+	printf("%d", t);
+	return 0;
+}
+int cantor(int a[], int n)
+{
+	int s = 0;
+	for (int i = 0; i < n; i++)
+	{
+		int x = 0, c = 1, m = 1;
+		for (int j = i + 1; j < n; j++)
+		{
+			if (a[j] < a[i])
+				x++;
+			m *= c;
+			c++;
+		}
+		s += x * m;
+	}
+	return s;
+}


### PR DESCRIPTION
使用VS编程时，在编译时，出现“xxx.exe无法进入”的问题。解决方法：将该Debug文件中的“xxx.exe”删除即行。